### PR TITLE
Merge upstream/master to fork

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ node_js:
   - '0.10'
   - '0.12'
   - 'iojs'
-  - 'node'
+  - '4'
+  - '5'
 
 script:
   - npm run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: node_js
 node_js:
   - '0.10'
   - '0.12'
-  - 'iojs'
   - '4'
   - '5'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
+sudo: false
+
 language: node_js
+
 node_js:
-  - "0.10"
-  - "0.11"
-before_script:
-  - npm install -g grunt-cli
+  - '0.10'
+  - '0.12'
+  - 'iojs'
+  - 'node'
+
+script:
+  - npm run test

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Here's some of my other Node projects:
 
 | Name | Description | npm&nbsp;Downloads |
 |---|---|---|
+| [`space‑hogs`](https://github.com/dylang/space-hogs) | Discover surprisingly large directories from the command line | [![space-hogs](https://img.shields.io/npm/dm/space-hogs.svg?style=flat-square)](https://www.npmjs.org/package/space-hogs) |
 | [`npm‑check`](https://github.com/dylang/npm-check) | Check for outdated, incorrect, and unused dependencies. | [![npm-check](https://img.shields.io/npm/dm/npm-check.svg?style=flat-square)](https://www.npmjs.org/package/npm-check) |
 | [`shortid`](https://github.com/dylang/shortid) | Amazingly short non-sequential url-friendly unique id generator. | [![shortid](https://img.shields.io/npm/dm/shortid.svg?style=flat-square)](https://www.npmjs.org/package/shortid) |
 | [`rss`](https://github.com/dylang/node-rss) | RSS feed generator. Add RSS feeds to any project. Supports enclosures and GeoRSS. | [![rss](https://img.shields.io/npm/dm/rss.svg?style=flat-square)](https://www.npmjs.org/package/rss) |
@@ -219,13 +220,13 @@ _This list was generated using [anthology](https://github.com/dylang/anthology).
 
 
 ### License
-Copyright (c) 2015 Dylan Greene, contributors.
+Copyright (c) 2016 Dylan Greene, contributors.
 
 Released under the [MIT license](https://tldrlegal.com/license/mit-license).
 
 Screenshots are [CC BY-SA](http://creativecommons.org/licenses/by-sa/4.0/) (Attribution-ShareAlike).
 
 ***
-_Generated using [grunt-readme](https://github.com/assemble/grunt-readme) with [grunt-templates-dylang](https://github.com/dylang/grunt-templates-dylang) on Wednesday, November 11, 2015._
+_Generated using [grunt-readme](https://github.com/assemble/grunt-readme) with [grunt-templates-dylang](https://github.com/dylang/grunt-templates-dylang) on Sunday, February 28, 2016._
 _To make changes to this document look in `/templates/readme/`
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## grunt-notify  [![Build Status](http://img.shields.io/travis/dylang/grunt-notify.svg?style=flat-square)](https://travis-ci.org/dylang/grunt-notify) [![grunt-notify](http://img.shields.io/npm/dm/grunt-notify.svg?style=flat-square)](https://www.npmjs.org/package/grunt-notify)
+## grunt-notify  [![Build Status](http://img.shields.io/travis/dylang/grunt-notify.svg)](https://travis-ci.org/dylang/grunt-notify) [![grunt-notify](http://img.shields.io/npm/dm/grunt-notify.svg)](https://www.npmjs.org/package/grunt-notify)
 
 > Automatic desktop notifications for Grunt errors and warnings using Growl for OS X or Windows, Mountain Lion and Mavericks Notification Center, and Notify-Send.
 
@@ -195,19 +195,19 @@ Run `grunt -v` (for `verbose` mode) to show `grunt-notify` debug messages. It wi
 
 
 
-### About the Author [![@dylang](https://img.shields.io/badge/github-dylang-green.svg?style=flat-square)](https://github.com/dylang) [![@dylang](https://img.shields.io/badge/twitter-dylang-blue.svg?style=flat-square)](https://twitter.com/dylang)
+### About the Author
 
-Hi! Thanks for checking `grunt-notify`! My name is **Dylan Greene**. When not overwhelmed with my two young kids I enjoy contributing
-to the open source community. I'm also a tech lead at [Opower](http://opower.com).
+Hi! Thanks for checking out this project! My name is **Dylan Greene**. When not overwhelmed with my two young kids I enjoy contributing
+to the open source community. I'm also a tech lead at [Opower](http://opower.com). [![@dylang](https://img.shields.io/badge/github-dylang-green.svg)](https://github.com/dylang) [![@dylang](https://img.shields.io/badge/twitter-dylang-blue.svg)](https://twitter.com/dylang)
 
 Here's some of my other Node projects:
 
 | Name | Description | npm&nbsp;Downloads |
-|---|---|--:|--:|
-| [`grunt‑prompt`](https://github.com/dylang/grunt-prompt) | Interactive prompt for your Grunt config using console checkboxes, text input with filtering, password fields. | [![grunt-prompt](https://img.shields.io/npm/dm/grunt-prompt.svg?style=flat-square)](https://www.npmjs.org/package/grunt-prompt) |
-| [`shortid`](https://github.com/dylang/shortid) | Amazingly short non-sequential url-friendly unique id generator. | [![shortid](https://img.shields.io/npm/dm/shortid.svg?style=flat-square)](https://www.npmjs.org/package/shortid) |
+|---|---|---|
 | [`npm‑check`](https://github.com/dylang/npm-check) | Check for outdated, incorrect, and unused dependencies. | [![npm-check](https://img.shields.io/npm/dm/npm-check.svg?style=flat-square)](https://www.npmjs.org/package/npm-check) |
+| [`shortid`](https://github.com/dylang/shortid) | Amazingly short non-sequential url-friendly unique id generator. | [![shortid](https://img.shields.io/npm/dm/shortid.svg?style=flat-square)](https://www.npmjs.org/package/shortid) |
 | [`rss`](https://github.com/dylang/node-rss) | RSS feed generator. Add RSS feeds to any project. Supports enclosures and GeoRSS. | [![rss](https://img.shields.io/npm/dm/rss.svg?style=flat-square)](https://www.npmjs.org/package/rss) |
+| [`grunt‑prompt`](https://github.com/dylang/grunt-prompt) | Interactive prompt for your Grunt config using console checkboxes, text input with filtering, password fields. | [![grunt-prompt](https://img.shields.io/npm/dm/grunt-prompt.svg?style=flat-square)](https://www.npmjs.org/package/grunt-prompt) |
 | [`xml`](https://github.com/dylang/node-xml) | Fast and simple xml generator. Supports attributes, CDATA, etc. Includes tests and examples. | [![xml](https://img.shields.io/npm/dm/xml.svg?style=flat-square)](https://www.npmjs.org/package/xml) |
 | [`changelog`](https://github.com/dylang/changelog) | Command line tool (and Node module) that generates a changelog in color output, markdown, or json for modules in npmjs.org's registry as well as any public github.com repo. | [![changelog](https://img.shields.io/npm/dm/changelog.svg?style=flat-square)](https://www.npmjs.org/package/changelog) |
 | [`grunt‑attention`](https://github.com/dylang/grunt-attention) | Display attention-grabbing messages in the terminal | [![grunt-attention](https://img.shields.io/npm/dm/grunt-attention.svg?style=flat-square)](https://www.npmjs.org/package/grunt-attention) |
@@ -219,12 +219,13 @@ _This list was generated using [anthology](https://github.com/dylang/anthology).
 
 
 ### License
-Copyright (c) 2014 Dylan Greene, contributors.
+Copyright (c) 2015 Dylan Greene, contributors.
 
 Released under the [MIT license](https://tldrlegal.com/license/mit-license).
 
 Screenshots are [CC BY-SA](http://creativecommons.org/licenses/by-sa/4.0/) (Attribution-ShareAlike).
 
 ***
-_Generated using [grunt-readme](https://github.com/assemble/grunt-readme) with [grunt-templates-dylang](https://github.com/dylang/grunt-templates-dylang) on Friday, November 7, 2014._
+_Generated using [grunt-readme](https://github.com/assemble/grunt-readme) with [grunt-templates-dylang](https://github.com/dylang/grunt-templates-dylang) on Wednesday, November 11, 2015._
+_To make changes to this document look in `/templates/readme/`
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## grunt-notify  [![Build Status](http://img.shields.io/travis/dylang/grunt-notify.svg)](https://travis-ci.org/dylang/grunt-notify) [![grunt-notify](http://img.shields.io/npm/dm/grunt-notify.svg)](https://www.npmjs.org/package/grunt-notify)
 
-> Automatic desktop notifications for Grunt errors and warnings using Growl for OS X or Windows, Mountain Lion and Mavericks Notification Center, and Notify-Send.
+> Automatic desktop notifications for Grunt errors and warnings. Supports OS X, Windows, Linux.
 
 
 

--- a/lib/hooks/notify-fail.js
+++ b/lib/hooks/notify-fail.js
@@ -7,7 +7,7 @@
  */
 'use strict';
 
-module.exports = function(grunt, options) {
+module.exports = function (grunt, options) {
 
   var message_count = 0;
   var StackParser = require('stack-parser');
@@ -17,27 +17,27 @@ module.exports = function(grunt, options) {
   var cwd = process.cwd();
 
   function toggleSuccessNotify() {
-	if (!!options.success) {
-	  grunt.util.hooker.hook(grunt.log, 'success', notifyHook);
-	} else {
-	  grunt.util.hooker.unhook(grunt.log, 'success');
-	}
+    if (!!options.success) {
+      grunt.util.hooker.hook(grunt.log, 'success', notifyHook);
+    } else {
+      grunt.util.hooker.unhook(grunt.log, 'success');
+    }
   }
 
   function watchForContribWatchWarnings(e) {
 
     if (!e || typeof e !== 'string') {
-        return;
+      return;
     }
 
     var msg = removeColor(e);
     msg = msg.replace(' Use --force to continue.', '');
 
     if (msg.indexOf('Warning:') === 0) {
-        return notifyHook(msg.replace('Warning: ', ''));
+      return notifyHook(msg.replace('Warning: ', ''));
     }
     if (msg.indexOf('Fatal error:') === 0) {
-        return notifyHook(msg.replace('Fatal error: ', ''));
+      return notifyHook(msg.replace('Fatal error: ', ''));
     }
 
     return e;
@@ -46,7 +46,7 @@ module.exports = function(grunt, options) {
   function exception(e) {
     var stackDump, stack, message;
 
-    if (e.stack && typeof e.stack !== 'string'){
+    if (e.stack && typeof e.stack !== 'string') {
       stackDump = StackParser.parse(e.stack);
       stack = stackDump[0];
 
@@ -110,9 +110,9 @@ module.exports = function(grunt, options) {
     message = message.replace(cwd, '').replace('\x07', '');
 
     return notify({
-      title:    options.title + (grunt.task.current.nameArgs ? ' ' + grunt.task.current.nameArgs : ''),
-      message:  message,
-	  duration: options.duration
+      title: options.title + (grunt.task.current.nameArgs ? ' ' + grunt.task.current.nameArgs : ''),
+      message: message,
+      duration: options.duration
     });
   }
 
@@ -135,7 +135,7 @@ module.exports = function(grunt, options) {
 
   function setOptions(opts) {
     options = opts;
-	toggleSuccessNotify();
+    toggleSuccessNotify();
   }
 
   return {

--- a/lib/platforms/growl-notify.js
+++ b/lib/platforms/growl-notify.js
@@ -87,8 +87,7 @@ function createTitleArg(title) {
 
 function createMessageArg(message) {
   return [
-    macOnly('-m'),
-    message
+    macOnly('-m ') + message
   ];
 }
 

--- a/lib/platforms/growl-notify.js
+++ b/lib/platforms/growl-notify.js
@@ -17,7 +17,7 @@ var spawn = require('../util/spawn');
 var cmd = 'growlnotify';
 var IS_MAC = os.type() === 'Darwin';
 var IS_WINDOWS = os.type() === 'Windows_NT';
-var DEFAULT_IMAGE = path.resolve(__dirname + '../../../images/grunt-logo.png');
+var DEFAULT_IMAGE = path.resolve(__dirname, '../../images/grunt-logo.png');
 
 function macOnly(string) {
   return IS_MAC ? string : '';

--- a/lib/platforms/hey-snarl.js
+++ b/lib/platforms/hey-snarl.js
@@ -17,7 +17,7 @@ var findApp = require('../util/findApp');
 var cmd = 'heysnarl.exe';
 
 var IS_WINDOWS = os.type() === 'Windows_NT';
-var DEFAULT_IMAGE = path.resolve(__dirname + '../../../images/grunt-logo.png');
+var DEFAULT_IMAGE = path.resolve(__dirname, '../../images/grunt-logo.png');
 
 function findInstall() {
 

--- a/lib/platforms/notification-center.js
+++ b/lib/platforms/notification-center.js
@@ -18,7 +18,7 @@ var semver = require('semver');
 // OSX notification system doesn't have an API Node can access so we are using
 // Grunt.app, a modified version of Terminal Notifier, but with the Grunt icon,
 // originally created by Eloy Durán https://github.com/alloy/terminal-notifier
-var cmd = path.resolve(__dirname + '../../../bin/Grunt.app/Contents/MacOS/Grunt');
+var cmd = path.resolve(__dirname, '../../bin/Grunt.app/Contents/MacOS/Grunt');
 
 function notificationCenterSupported(options) {
   var IS_MAC = os.type() === 'Darwin';

--- a/lib/platforms/notify-send.js
+++ b/lib/platforms/notify-send.js
@@ -12,7 +12,7 @@ var NOTIFY_TYPE = 'notify-send';
 var path = require('path');
 var spawn = require('../util/spawn');
 var findApp = require('../util/findApp');
-var DEFAULT_IMAGE = path.resolve(__dirname + '../../../images/grunt-logo.png');
+var DEFAULT_IMAGE = path.resolve(__dirname, '../../images/grunt-logo.png');
 var DEFAULT_DURATION = 3000;
 var CMD = 'notify-send';
 

--- a/lib/platforms/toaster.js
+++ b/lib/platforms/toaster.js
@@ -16,9 +16,9 @@ var semver = require('semver');
 
 // A wee Win8 console notifications app. Post toast notifications from the console, making it easy to integrate into existing batch scripts etc.
 // Toaster by Nels Oscar https://github.com/nels-o/toaster
-var CMD = path.resolve(__dirname + '../../../bin/toaster/toast.exe');
+var CMD = path.resolve(__dirname, '../../bin/toaster/toast.exe');
 var IS_WINDOWS = os.type() === 'Windows_NT';
-var DEFAULT_IMAGE = path.resolve(__dirname + '../../../images/grunt-logo.png');
+var DEFAULT_IMAGE = path.resolve(__dirname, '../../images/grunt-logo.png');
 
 
 function supported(options) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-notify",
   "description": "Automatic desktop notifications for Grunt errors and warnings. Supports OS X, Windows, Linux.",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "homepage": "https://github.com/dylang/grunt-notify",
   "author": {
     "name": "Dylan Greene",
@@ -17,17 +17,17 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "chai": "^3.4.1",
+    "chai": "^3.5.0",
     "grunt-cli": "^0.1.13",
-    "grunt-contrib-jshint": "^0.11.3",
+    "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-mocha-test": "^0.12.7",
     "grunt-release": "^0.13.0",
     "grunt-templates-dylang": "^1.0.12",
-    "load-grunt-tasks": "^3.3.0",
-    "mocha": "^2.3.3",
-    "proxyquire": "^1.7.3",
-    "time-grunt": "^1.2.2"
+    "load-grunt-tasks": "^3.4.0",
+    "mocha": "^2.4.5",
+    "proxyquire": "^1.7.4",
+    "time-grunt": "^1.3.0"
   },
   "keywords": [
     "gruntplugin",
@@ -43,8 +43,8 @@
     "automatic"
   ],
   "dependencies": {
-    "semver": "^5.0.3",
-    "stack-parser": "~0.0.1",
-    "which": "^1.2.0"
+    "semver": "^5.1.0",
+    "stack-parser": "^0.0.1",
+    "which": "^1.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-notify",
   "description": "Automatic desktop notifications for Grunt errors and warnings. Supports OS X, Windows, Linux.",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "homepage": "https://github.com/dylang/grunt-notify",
   "author": {
     "name": "Dylan Greene",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-notify",
-  "description": "Automatic desktop notifications for Grunt errors and warnings using Growl for OS X or Windows, Mountain Lion and Mavericks Notification Center, and Notify-Send.",
-  "version": "0.4.1",
+  "description": "Automatic desktop notifications for Grunt errors and warnings. Supports OS X, Windows, Linux.",
+  "version": "0.4.2",
   "homepage": "https://github.com/dylang/grunt-notify",
   "author": {
     "name": "Dylan Greene",
@@ -9,37 +9,24 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/dylang/grunt-notify.git"
+    "url": "https://github.com/dylang/grunt-notify"
   },
-  "bugs": {
-    "url": "https://github.com/dylang/grunt-notify/issues"
-  },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/dylang/grunt-notify/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": "MIT",
   "main": "Gruntfile.js",
-  "engines": {
-    "node": ">= 0.10.0"
-  },
   "scripts": {
     "test": "grunt test"
   },
   "devDependencies": {
-    "chai": "^1.9.2",
-    "grunt-contrib-jshint": "^0.10.0",
+    "chai": "^3.4.1",
+    "grunt-cli": "^0.1.13",
+    "grunt-contrib-jshint": "^0.11.3",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-mocha-test": "^0.12.0",
-    "grunt-release": "^0.7.0",
-    "grunt-templates-dylang": "^1.0.0",
-    "load-grunt-tasks": "^1.0.0",
-    "proxyquire": "^1.0.1",
-    "time-grunt": "^1.0.0"
-  },
-  "peerDependencies": {
-    "grunt": "~0.4.1"
+    "grunt-mocha-test": "^0.12.7",
+    "grunt-release": "^0.13.0",
+    "grunt-templates-dylang": "^1.0.10",
+    "load-grunt-tasks": "^3.3.0",
+    "proxyquire": "^1.7.3",
+    "time-grunt": "^1.2.2"
   },
   "keywords": [
     "gruntplugin",
@@ -55,8 +42,8 @@
     "automatic"
   ],
   "dependencies": {
-    "semver": "^4.1.0",
+    "semver": "^5.0.3",
     "stack-parser": "~0.0.1",
-    "which": "~1.0.5"
+    "which": "^1.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,9 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-mocha-test": "^0.12.7",
     "grunt-release": "^0.13.0",
-    "grunt-templates-dylang": "^1.0.10",
+    "grunt-templates-dylang": "^1.0.12",
     "load-grunt-tasks": "^3.3.0",
+    "mocha": "^2.3.3",
     "proxyquire": "^1.7.3",
     "time-grunt": "^1.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-notify",
   "description": "Automatic desktop notifications for Grunt errors and warnings. Supports OS X, Windows, Linux.",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "homepage": "https://github.com/dylang/grunt-notify",
   "author": {
     "name": "Dylan Greene",


### PR DESCRIPTION
This PR merges the current master from upstream to master on grayside/grunt-notify, which includes the fix to remove peer dependencies for Grunt 1.x.

It may be worth a follow up on the PR that is the reason for this fork so we can get back to using an official release for grunt-drupal-tasks.
